### PR TITLE
refactor of the port / pin modules

### DIFF
--- a/examples/connect_pin_to_led.rs
+++ b/examples/connect_pin_to_led.rs
@@ -4,16 +4,15 @@
 
 use teensy::*;
 
-define_panic!{empty}
+define_panic! {empty}
 
 #[no_mangle]
 fn main() {
-    let (led, pin) = unsafe { make_pin!(led, 3) };
+    let (led, mut pin) = unsafe { make_pin!(led, 1) };
 
-    // TODO: make this safe
     unsafe {
-        (pin.port.as_mut().unwrap()).set_pin_pe(pin.pin, true);
-        (pin.port.as_mut().unwrap()).set_pin_ps(pin.pin, false);
+        pin.set_pin_pe(true);
+        pin.set_pin_ps(false);
     }
 
     let mut led_out = led.make_gpio();

--- a/src/port/gpio.rs
+++ b/src/port/gpio.rs
@@ -1,3 +1,4 @@
+use super::pin::Pin;
 use super::port::PortName;
 use volatile::Volatile;
 
@@ -13,7 +14,7 @@ struct GpioBitband {
 
 pub struct Gpio {
     gpio: *mut GpioBitband,
-    pin: usize,
+    pin: Pin,
 }
 
 impl Gpio {
@@ -21,8 +22,8 @@ impl Gpio {
     /// gpio mode. Prefer using function like `make_gpio` instead of calling this one directly.
     /// TODO: maybe we should move the `set_pin_mode` call from `make_gpio` to this function.
     /// This would allow direct call to this function
-    pub unsafe fn new(port: PortName, pin: usize) -> Gpio {
-        let gpio = match port {
+    pub unsafe fn new(pin: Pin) -> Gpio {
+        let gpio = match pin.portname {
             PortName::A => 0x43FE_0000 as *mut GpioBitband,
             PortName::B => 0x43FE_0800 as *mut GpioBitband,
             PortName::C => 0x43FE_1000 as *mut GpioBitband,
@@ -36,14 +37,14 @@ impl Gpio {
     /// Switch the pin in input mode (can read but not write)
     pub fn input(&mut self) {
         unsafe {
-            (*self.gpio).pddr[self.pin].write(0);
+            (*self.gpio).pddr[self.pin.id].write(0);
         }
     }
 
     /// Switch the pin in output mode (can write but not read)
     pub fn output(&mut self) {
         unsafe {
-            (*self.gpio).pddr[self.pin].write(1);
+            (*self.gpio).pddr[self.pin.id].write(1);
         }
     }
 
@@ -55,7 +56,7 @@ impl Gpio {
     /// gpio.read();
     /// ```
     pub fn read(&mut self) -> u32 {
-        unsafe { (*self.gpio).pdir[self.pin].read() }
+        unsafe { (*self.gpio).pdir[self.pin.id].read() }
     }
 
     /// Before use, call the `output` function
@@ -67,7 +68,7 @@ impl Gpio {
     /// ```
     pub fn high(&mut self) {
         unsafe {
-            (*self.gpio).psor[self.pin].write(1);
+            (*self.gpio).psor[self.pin.id].write(1);
         }
     }
 
@@ -80,7 +81,7 @@ impl Gpio {
     /// ```
     pub fn low(&mut self) {
         unsafe {
-            (*self.gpio).pcor[self.pin].write(1);
+            (*self.gpio).pcor[self.pin.id].write(1);
         }
     }
 
@@ -93,7 +94,7 @@ impl Gpio {
     /// ```
     pub fn toggle(&mut self) {
         unsafe {
-            (*self.gpio).ptor[self.pin].write(1);
+            (*self.gpio).ptor[self.pin.id].write(1);
         }
     }
 }


### PR DESCRIPTION
move all the pin's specific function into the pin module. 
To do this, the pin now need to keep a pointer to the pcr field of the port module.

This give direct access to the pull resistor and pull enable registers.